### PR TITLE
Fix unread count background color in folders tree

### DIFF
--- a/Vienna/Sources/Main window/FoldersTree.m
+++ b/Vienna/Sources/Main window/FoldersTree.m
@@ -1015,20 +1015,12 @@
 		else if (folder.unreadCount)
 		{
 			[realCell setCount:folder.unreadCount];
-            if (@available(macOS 10.14, *)) {
-                realCell.backgroundColor = NSColor.controlAccentColor;
-            } else {
-                realCell.backgroundColor = [NSColor colorForControlTint:NSColor.currentControlTint];
-            }
+			realCell.backgroundColor = NSColor.controlBackgroundColor;
 		}
 		else if (folder.childUnreadCount && ![olv isItemExpanded:item])
 		{
 			[realCell setCount:folder.childUnreadCount];
-            if (@available(macOS 10.14, *)) {
-                realCell.backgroundColor = NSColor.controlAccentColor;
-            } else {
-                realCell.backgroundColor = [NSColor colorForControlTint:NSColor.currentControlTint];
-            }
+			realCell.backgroundColor = NSColor.controlBackgroundColor;
 		}
 		else
 		{

--- a/Vienna/Sources/Shared/ImageAndTextCell.m
+++ b/Vienna/Sources/Shared/ImageAndTextCell.m
@@ -43,7 +43,7 @@
 		hasCount = NO;
 		count = 0;
         countLabelShadow = [self defaultCountLabelShadow];
-		[self setCountBackgroundColour:[NSColor shadowColor]];
+		[self setCountBackgroundColour:NSColor.selectedTextBackgroundColor];
 	}
 	return self;
 }


### PR DESCRIPTION
Solve :
- hard to read unread count in recent releases (especially if background
  is blue, issue #1304) 
- overly aggressive unread count in Light mode after last commit